### PR TITLE
windows と *nix 系でタイムゾーンの仕様が違う問題を解決

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,9 @@ darwin-amd64: gakujo-google-calendar_darwin_amd64
 darwin-arm64: gakujo-google-calendar_darwin_arm64
 
 gakujo-google-calendar_windows_amd64.exe: credentials.json
-	CGO_ENABLED=1 \
+	CGO_ENABLED=0 \
 	GOOS=windows \
 	GOARCH=amd64 \
-	CC=x86_64-w64-mingw32-gcc \
 	go build \
 		-ldflags \
 		-H=windowsgui \

--- a/gakujo/scrape/util.go
+++ b/gakujo/scrape/util.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"time"
+	_ "time/tzdata"
 )
 
 func replaceAndTrim(s string) string {


### PR DESCRIPTION
- `time/tzdata` を埋め込みました
- ついでに `CGO_ENABLED=0` をしました(c に依存していないので)